### PR TITLE
More fixes

### DIFF
--- a/src/lib/components/ControlModal.svelte
+++ b/src/lib/components/ControlModal.svelte
@@ -21,7 +21,7 @@ export let open;
 export let toggle;
 export let target: TargetOfEvaluation;
 export let controlsInScope: ControlInScope[];
-export let catalog:Catalog;
+export let catalog: Catalog;
 
 $: controlsInScopeUrls = controlsInScope.map((cis) => controlUrl2(cis, target.catalogId));
 
@@ -70,46 +70,46 @@ function change(idx: number, ev: Event) {
 	<ModalBody>
 		<div class="container">
 			<!-- Hide add/remove of controls if catalog has all controls in scope  -->
-			{#if  !catalog.allInScope}
-			<div class="row">
-				<div class="col-sm">
-					<select
-						class="form-control"
-						name="controls"
-						id="controls"
-						multiple
-						bind:value={controlsToAdd}
-					>
-						{#each controls2 as control}
-							<option value={controlUrl(control, target.catalogId)}>
-								{#if control.parentControlId != null}&nbsp;{/if}
-								{control.id}: {control.name}
-							</option>
-						{/each}
-					</select>
+			{#if !catalog.allInScope}
+				<div class="row">
+					<div class="col-sm">
+						<select
+							class="form-control"
+							name="controls"
+							id="controls"
+							multiple
+							bind:value={controlsToAdd}
+						>
+							{#each controls2 as control}
+								<option value={controlUrl(control, target.catalogId)}>
+									{#if control.parentControlId != null}&nbsp;{/if}
+									{control.id}: {control.name}
+								</option>
+							{/each}
+						</select>
+					</div>
+					<div class="col-sm">
+						<Button on:click={add}>add</Button>
+						<Button on:click={remove}>remove</Button>
+					</div>
+					<div class="col-sm">
+						<select
+							class="form-control"
+							name="selected-controls"
+							id="selected-controls"
+							multiple
+							bind:value={controlsToRemove}
+						>
+							{#each controls1 as control}
+								<option value={controlUrl(control, target.catalogId)}>
+									{#if control.parentControlId != null}&nbsp;{/if}
+									{control.id}: {control.name}
+								</option>
+							{/each}
+						</select>
+					</div>
 				</div>
-				<div class="col-sm">
-					<Button on:click={add}>add</Button>
-					<Button on:click={remove}>remove</Button>
-				</div>
-				<div class="col-sm">
-					<select
-						class="form-control"
-						name="selected-controls"
-						id="selected-controls"
-						multiple
-						bind:value={controlsToRemove}
-					>
-						{#each controls1 as control}
-							<option value={controlUrl(control, target.catalogId)}>
-								{#if control.parentControlId != null}&nbsp;{/if}
-								{control.id}: {control.name}
-							</option>
-						{/each}
-					</select>
-				</div>
-			</div>
- 			<hr />
+				<hr />
 			{/if}
 			<div class="row">
 				<div class="col-sm">
@@ -135,8 +135,8 @@ function change(idx: number, ev: Event) {
 							on:change={(e) => change(idx, e)}
 						>
 							<option value="MONITORING_STATUS_UNSPECIFIED">unspecified</option>
-							<option value="MONITORING_STATUS_CONTINUOUSLY_MONITORED">
-								continuously monitored
+							<option value="MONITORING_STATUS_AUTOMATICALLY_MONITORED">
+								automatically monitored
 							</option>
 							<option value="MONITORING_STATUS_MANUALLY_MONITORED">manually monitored</option>
 							<option value="MONITORING_STATUS_DELEGATED">delegated</option>

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -415,7 +415,7 @@ export async function listTargetsOfEvaluation(serviceId: string, fetch = window.
  * @returns an array of {@link ControlInScope} objects.
  */
 export async function listControlsInScope(serviceId: string, catalogId: string, fetch = window.fetch): Promise<ControlInScope[]> {
-    const apiUrl = clouditorize(`/v1/orchestrator/cloud_services/${serviceId}/toes/${catalogId}/controls_in_scope?pageSize=1000`)
+    const apiUrl = clouditorize(`/v1/orchestrator/cloud_services/${serviceId}/toes/${catalogId}/controls_in_scope?pageSize=1000&orderBy=control_id&asc=true`)
 
     return fetch(apiUrl, {
         method: 'GET',
@@ -477,9 +477,9 @@ export async function getCatalog(id: string, fetch = window.fetch): Promise<Cata
 export async function listControls(catalogId?: string, categoryName?: string, fetch = window.fetch): Promise<Control[]> {
     let apiUrl: string;
     if (catalogId != null && categoryName != null) {
-        apiUrl = clouditorize(`/v1/orchestrator/catalogs/${catalogId}/categories/${categoryName}/controls?pageSize=1000`)
+        apiUrl = clouditorize(`/v1/orchestrator/catalogs/${catalogId}/categories/${categoryName}/controls?pageSize=1000&orderBy=id&asc=true`)
     } else {
-        apiUrl = clouditorize(`/v1/orchestrator/controls?pageSize=1000`)
+        apiUrl = clouditorize(`/v1/orchestrator/controls?pageSize=1000&orderBy=id&asc=true`)
     }
 
     return fetch(apiUrl, {

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -415,7 +415,7 @@ export async function listTargetsOfEvaluation(serviceId: string, fetch = window.
  * @returns an array of {@link ControlInScope} objects.
  */
 export async function listControlsInScope(serviceId: string, catalogId: string, fetch = window.fetch): Promise<ControlInScope[]> {
-    const apiUrl = clouditorize(`/v1/orchestrator/cloud_services/${serviceId}/toes/${catalogId}/controls_in_scope?pageSize=1000&orderBy=control_id&asc=true`)
+    const apiUrl = clouditorize(`/v1/orchestrator/cloud_services/${serviceId}/toes/${catalogId}/controls_in_scope?pageSize=1500&orderBy=control_id&asc=true`)
 
     return fetch(apiUrl, {
         method: 'GET',
@@ -477,9 +477,9 @@ export async function getCatalog(id: string, fetch = window.fetch): Promise<Cata
 export async function listControls(catalogId?: string, categoryName?: string, fetch = window.fetch): Promise<Control[]> {
     let apiUrl: string;
     if (catalogId != null && categoryName != null) {
-        apiUrl = clouditorize(`/v1/orchestrator/catalogs/${catalogId}/categories/${categoryName}/controls?pageSize=1000&orderBy=id&asc=true`)
+        apiUrl = clouditorize(`/v1/orchestrator/catalogs/${catalogId}/categories/${categoryName}/controls?pageSize=1500&orderBy=id&asc=true`)
     } else {
-        apiUrl = clouditorize(`/v1/orchestrator/controls?pageSize=1000&orderBy=id&asc=true`)
+        apiUrl = clouditorize(`/v1/orchestrator/controls?pageSize=1500&orderBy=id&asc=true`)
     }
 
     return fetch(apiUrl, {

--- a/src/lib/orchestrator.ts
+++ b/src/lib/orchestrator.ts
@@ -477,9 +477,9 @@ export async function getCatalog(id: string, fetch = window.fetch): Promise<Cata
 export async function listControls(catalogId?: string, categoryName?: string, fetch = window.fetch): Promise<Control[]> {
     let apiUrl: string;
     if (catalogId != null && categoryName != null) {
-        apiUrl = clouditorize(`/v1/orchestrator/catalogs/${catalogId}/categories/${categoryName}/controls?pageSize=500`)
+        apiUrl = clouditorize(`/v1/orchestrator/catalogs/${catalogId}/categories/${categoryName}/controls?pageSize=1000`)
     } else {
-        apiUrl = clouditorize(`/v1/orchestrator/controls`)
+        apiUrl = clouditorize(`/v1/orchestrator/controls?pageSize=1000`)
     }
 
     return fetch(apiUrl, {

--- a/src/routes/cloud/[...id]/configuration/+page.svelte
+++ b/src/routes/cloud/[...id]/configuration/+page.svelte
@@ -6,7 +6,7 @@ import { Button, FormGroup, Input } from 'sveltestrap';
 
 export let data: import('./$types').PageData;
 
-async function save(event) {
+async function save() {
 	try {
 		data.service = await updateCloudService(data.service);
 		toast.push('Cloud service updated.', { classes: ['toast-success'] });

--- a/src/routes/cloud/[...id]/configuration/toe/+page.ts
+++ b/src/routes/cloud/[...id]/configuration/toe/+page.ts
@@ -5,7 +5,7 @@ export const load: PageLoad = async ({ fetch, parent }) => {
     const data = await parent();
     const targets = await listTargetsOfEvaluation(data.service.id, fetch);
     const scopes = await Promise.all(targets.map((toe) =>
-        listControlsInScope(toe.cloudServiceId, toe.catalogId, fetch)))
+        listControlsInScope(data.service.id, toe.catalogId, fetch)))
 
     return {
         targets: targets,

--- a/src/routes/cloud/[...id]/metrics/+page.svelte
+++ b/src/routes/cloud/[...id]/metrics/+page.svelte
@@ -38,8 +38,6 @@ The following metrics are configured for the Cloud Service.
 						{#await getMetricConfiguration(data.service.id, metric.id)}
 						{:then config}
 							<MetricConfigurationBlock {config} />
-						{:catch}
-						<p>No configuration available</p>
 						{/await}
 					</td>
 				</tr>


### PR DESCRIPTION
This PR fixes 
- Update listControlsInScope call with correct Cloud Service ID
- Increases listControlInScope page size and adds ordering  
- Increases listControls page size and adds ordering  
- Updates naming of MonitoringStatus 

The same ordering of controls is necessary for the UI. Otherwise other control ids can be used than the displayed ones.